### PR TITLE
Fix task window order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/gui/task_window.py
+++ b/gui/task_window.py
@@ -6,6 +6,9 @@ def open_task_window(parent, logic, year, month, day):
     top = ctk.CTkToplevel(parent)
     top.title("Dodaj zadanie")
     top.geometry("400x300")
+    top.lift()
+    top.attributes("-topmost", True)
+    top.after_idle(top.attributes, "-topmost", False)
 
     date_str = format_date(datetime(year, month, day))
 


### PR DESCRIPTION
## Summary
- raise the task window above the main app
- ignore local Python cache files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68738d3e3694832585f7a4c6135a7fb6